### PR TITLE
Fjerne Studvest-tekst og logo

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,9 +19,9 @@ function getStatementFromUrlParam(): ValgomatData {
   );
   // Change default statement here every year
   let statementsCsv = lister2023CSV;
-  let introTextHtml = `Årets valgomat er finansiert av Studentenes valgstyre, utviklet av
-        friByte og redaksjonelt utformet av Studvest, som har samlet informasjon
-        fra listene som stiller til valg helt uavhengig av de andre partene.`;
+  let introTextHtml = `Årets valgomat er utviklet av
+        friByte og redaksjonelt utformet av Studentparlamentet ved Universitetet i Bergen, som har samlet informasjon
+        fra listene som stiller til valg.`;
   let resultTextHtml = `Husk at valgomaten bare er veiledende, og ikke en fasit på hva du skal
       stemme. Vi oppfordrer til å lese mer om hva listene mener. Vi har blant
       annet intervjuet listekandidatene

--- a/src/components/Forside.vue
+++ b/src/components/Forside.vue
@@ -40,9 +40,6 @@ function restart() {
     <footer class="footer">
       <p>Laget av:</p>
       <p class="logos">
-        <a href="https://studvest.no" target="_blank"
-          ><img class="logo" :src="studvestLogoSrc" alt="Studvest"
-        /></a>
         <a href="https://fribyte.no" target="_blank"
           ><img class="logo" :src="friByteSrc" alt="fribyte"
         /></a>

--- a/src/components/StatementForm.vue
+++ b/src/components/StatementForm.vue
@@ -11,7 +11,7 @@ defineEmits<{
 }>();
 
 const userValue = ref<StatementValue>(0);
-let options = {
+const options = {
   "Helt uenig": -2,
   "Litt Uenig": -1,
   "Litt enig": 1,


### PR DESCRIPTION
Fjernet Studvest-teksten og logoen fra valgomaten, ettersom studentparlamentet selv skal utforme spørsmålene for valget i 2025.

<img width="1499" alt="bilde" src="https://github.com/user-attachments/assets/d62eb1cb-15f0-4286-9d25-cc5d8e40ba05" />
